### PR TITLE
echo output

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -92,6 +92,7 @@ jobs:
           EOF
           output=$(terraform apply --auto-approve --input=false -no-color)
           output="${output//$'\n'/\%0A}"
+          echo $output
           echo "::set-output name=stdout::$output"
         continue-on-error: true
         working-directory: ${{ inputs.tf_working_directory }}


### PR DESCRIPTION
The current approach swallows the `terraform apply` output, which we still want to display in the console because not every workflow call has a PR to comment on.