### PR TITLE
Roll up prs with flag in plan

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -10,6 +10,11 @@ on:
         required: false
         type: string
         default: ''
+      merge_prs:
+        description: Flag to roll up open PRs
+        required: false
+        type: boolean
+        default: false
       tf_var_json:
         description: A JSON string to write into terraform.tfvars.json when planning.
         required: false
@@ -48,6 +53,19 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref:  ${{ inputs.github_ref }}
+          fetch-depth: 0
+
+      - name: User config
+        if: ${{ inputs.merge_prs }}
+        run: |-
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Rollup open PRs
+        if: ${{ inputs.merge_prs }}
+        run: |-
+          chmod +x "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
+          "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:


### PR DESCRIPTION
- Use the merge_prs input flag to determine whether to roll up open PRs in plan. 
- The flag will only be set for the dev command in the terraform workflow commands. 
- Will do the same for apply if this is successful.