### PR TITLE
Add push_image.yml, make some changes to plan/dev

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -144,14 +144,15 @@ jobs:
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}
           EOF
-          terraform apply --auto-approve --input=false -no-color 2>&1 | tee tf_output.txt
+          terraform apply --auto-approve --input=false -no-color 2>&1 | tee apply_output.txt
           # Use PIPESTATUS to capture errors in terraform apply:
           # See https://linux.samba.narkive.com/Oc6yBphD/clug-tee-eats-the-return-code-of-the-previous-entry-in-the-pipeline#post4
           tf_status=${PIPESTATUS[0]}
-          output=$(cat tf_output.txt)
+          output=$(cat apply_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"
           echo "::set-output name=stdout::$output"
+          rm apply_output.txt
           exit $tf_status
         working-directory: ${{ inputs.tf_working_directory }}
 

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -113,6 +113,7 @@ jobs:
       - name: Terraform Apply
         id: apply
         run: |-
+          echo ${{ inputs.tf_var_json }}
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -121,7 +121,7 @@ jobs:
           EOF
           echo "resulting file:"
           cat terraform.tfvars.json
-          terraform apply --auto-approve --input=false -no-color | tee tf_output.txt
+          terraform apply --auto-approve --input=false -no-color 2>&1 | tee tf_output.txt
           output=$(cat tf_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -122,15 +122,18 @@ jobs:
           echo "resulting file:"
           cat terraform.tfvars.json
           terraform apply --auto-approve --input=false -no-color 2>&1 | tee tf_output.txt
+          # Use PIPESTATUS to capture errors in terraform apply:
+          # See https://linux.samba.narkive.com/Oc6yBphD/clug-tee-eats-the-return-code-of-the-previous-entry-in-the-pipeline#post4
+          tf_status=${PIPESTATUS[0]}
           output=$(cat tf_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"
           echo "::set-output name=stdout::$output"
-        continue-on-error: true
+          exit $tf_status
         working-directory: ${{ inputs.tf_working_directory }}
 
       - uses: actions/github-script@v2.0.1
-        if: ${{ github.event.issue.pull_request }}
+        if: github.event.issue.pull_request && (success() || failure())
         env:
           FMT_OUT: ${{ steps.fmt.outputs.stdout }}
           APPLY_OUT: ${{ steps.apply.outputs.stdout }}
@@ -149,6 +152,3 @@ jobs:
               body: output
             })
 
-      - name: Terraform Apply Status
-        if: steps.apply.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -10,7 +10,12 @@ on:
         type: string
         default: ''
       merge_prs:
-        description: Flag to roll up open PRs
+        description: Flag to roll up all open PRs
+        required: false
+        type: boolean
+        default: false
+      merge_stage_prs:
+        description: Flag to roll up open PRs with a "stage" label
         required: false
         type: boolean
         default: false
@@ -64,7 +69,7 @@ jobs:
           fetch-depth: 0
 
       - name: User config
-        if: ${{ inputs.merge_prs }}
+        if: ${{ inputs.merge_prs || inputs.merge_stage_prs }}
         run: |-
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -72,8 +77,30 @@ jobs:
       - name: Rollup open PRs
         if: ${{ inputs.merge_prs }}
         run: |-
-          chmod +x "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
-          "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Rollup open stage PRs
+        if: ${{ inputs.merge_stage_prs }}
+        run: |-
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -113,11 +113,14 @@ jobs:
       - name: Terraform Apply
         id: apply
         run: |-
+          echo "input JSON:"
           echo ${{ inputs.tf_var_json }}
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}
           EOF
+          echo "resulting file:"
+          cat terraform.tfvars.json
           terraform apply --auto-approve --input=false -no-color | tee tf_output.txt
           output=$(cat tf_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -118,8 +118,8 @@ jobs:
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}
           EOF
-          output=$(terraform apply --auto-approve --input=false -no-color)
-          echo $output
+          terraform apply --auto-approve --input=false -no-color | tee tf_output.txt
+          output=$(cat tf_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"
           echo "::set-output name=stdout::$output"

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -140,14 +140,10 @@ jobs:
       - name: Terraform Apply
         id: apply
         run: |-
-          echo "input JSON:"
-          echo ${{ inputs.tf_var_json }}
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}
           EOF
-          echo "resulting file:"
-          cat terraform.tfvars.json
           terraform apply --auto-approve --input=false -no-color 2>&1 | tee tf_output.txt
           # Use PIPESTATUS to capture errors in terraform apply:
           # See https://linux.samba.narkive.com/Oc6yBphD/clug-tee-eats-the-return-code-of-the-previous-entry-in-the-pipeline#post4

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -160,22 +160,22 @@ jobs:
           cat <<- EOF >> terraform.tfvars.json
             ${{ inputs.tf_var_json }}
           EOF
-          terraform plan -input=false -no-color -out=terraform.plan
-        continue-on-error: true
-        working-directory: ${{ inputs.tf_working_directory }}
-
-      - id: show_plan
-        run: |-
-          output=$(terraform show -no-color terraform.plan)
+          terraform plan -input=false -no-color -out=terraform.plan | tee plan_output.txt
+          # Use PIPESTATUS to capture errors in terraform apply:
+          # See https://linux.samba.narkive.com/Oc6yBphD/clug-tee-eats-the-return-code-of-the-previous-entry-in-the-pipeline#post4
+          tf_status=${PIPESTATUS[0]}
+          output=$(cat plan_output.txt)
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"
           echo "::set-output name=stdout::$output"
+          exit $tf_status
         working-directory: ${{ inputs.tf_working_directory }}
 
       - uses: actions/github-script@v2.0.1
+        if: github.event.issue.pull_request && (success() || failure())
         env:
           FMT_OUT: ${{ steps.fmt.outputs.stdout }}
-          PLAN_OUT: ${{ steps.show_plan.outputs.stdout }}
+          PLAN_OUT: ${{ steps.plan.outputs.stdout }}
         with:
           script: |
             const output = `#### Initialization: ️${{ steps.init.outcome }}
@@ -197,12 +197,9 @@ jobs:
             })
 
       - name: tfsec
+        if: success() || failure()
         uses: reviewdog/action-tfsec@master
         with:
           reporter: github-pr-review
           fail_on_error: "false"
           filter_mode: "nofilter" # Check all files, not just the diff
-
-      - name: Terraform Plan Status
-        if: steps.plan.outcome == 'failure' || steps.fmt.outcome == 'failure'
-        run: exit 1

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -11,7 +11,12 @@ on:
         type: string
         default: ''
       merge_prs:
-        description: Flag to roll up open PRs
+        description: Flag to roll up all open PRs
+        required: false
+        type: boolean
+        default: false
+      merge_stage_prs:
+        description: Flag to roll up open PRs with a "stage" label
         required: false
         type: boolean
         default: false
@@ -65,7 +70,7 @@ jobs:
           fetch-depth: 0
 
       - name: User config
-        if: ${{ inputs.merge_prs }}
+        if: ${{ inputs.merge_prs || inputs.merge_stage_prs }}
         run: |-
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -73,8 +78,30 @@ jobs:
       - name: Rollup open PRs
         if: ${{ inputs.merge_prs }}
         run: |-
-          chmod +x "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
-          "${GITHUB_WORKSPACE}/.github/workflows/merge_prs.sh"
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Rollup open stage PRs
+        if: ${{ inputs.merge_stage_prs }}
+        run: |-
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -168,6 +168,7 @@ jobs:
           output="${output/Note: Objects have changed*Terraform will perform the following actions/Terraform will perform the following actions}"
           output="${output//$'\n'/\%0A}"
           echo "::set-output name=stdout::$output"
+          rm plan_output.txt
           exit $tf_status
         working-directory: ${{ inputs.tf_working_directory }}
 

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,0 +1,63 @@
+name: "Build and Push Image"
+
+on:
+  workflow_call:
+    inputs:
+      dockerfile:
+        description: Name of the dockerfile to build and push
+        required: True
+        type: string
+    secrets:
+      repository:
+        description: Name of the repo within Container Registry to push into
+        required: True
+      gcp_project_id:
+        required: true
+      gcp_service_account_key:
+        required: true
+      k8s_cluster_id:
+        required: false
+      k8s_cluster_zone:
+        required: false
+      ssh_agent_private_key:
+        required: true
+
+jobs:
+  Push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.ssh_agent_private_key }}
+
+      - uses: google-github-actions/auth@v0
+        with:
+          project_id: ${{ secrets.gcp_project_id }}
+          credentials_json: ${{ secrets.gcp_service_account_key }}
+
+      - uses: google-github-actions/setup-gcloud@v0 # terraform-bot
+
+      - run: |-
+          gcloud --quiet auth configure-docker
+
+      # Get the GKE credentials, so we can apply against the cluster
+      - name: get-credentials
+        # Workaround to https://github.com/actions/runner/issues/520
+        env:
+          HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
+        if: env.HAS_CREDENTIALS
+        run: |-
+          gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
+
+
+      - name: Build and push image
+        uses: docker/build-push-action@v1
+        with:
+          dockerfile: ${{ inputs.dockerfile }}
+          username: _json_key
+          password: ${{ secrets.gcp_service_account_key }}
+          registry: gcr.io
+          repository: ${{ secrets.repository }}
+          tags: ${{ github.sha }}

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -5,12 +5,22 @@ on:
     inputs:
       dockerfile:
         description: Name of the dockerfile to build and push
-        required: True
+        required: true
         type: string
+      merge_prs:
+        description: Flag to roll up open PRs
+        required: false
+        type: boolean
+        default: false
+      merge_stage_prs:
+        description: Flag to roll up open PRs with a "stage" label
+        required: false
+        type: boolean
+        default: false
     secrets:
       repository:
         description: Name of the repo within Container Registry to push into
-        required: True
+        required: true
       gcp_project_id:
         required: true
       gcp_service_account_key:
@@ -27,6 +37,40 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: User config
+        if: ${{ inputs.merge_prs || inputs.merge_stage_prs }}
+        run: |-
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+      - name: Rollup open PRs
+        if: ${{ inputs.merge_prs }}
+        run: |-
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Rollup open stage PRs
+        if: ${{ inputs.merge_stage_prs }}
+        run: |-
+          git checkout origin/main
+          echo "Open PRs to deploy:"
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,author,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .author.login }} {{ .mergeable }}
+          {{end}}" | sort -n
+          echo "-----"
+          gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
+            -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
+          {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -8,7 +8,7 @@ on:
         required: true
         type: string
       merge_prs:
-        description: Flag to roll up open PRs
+        description: Flag to roll up all open PRs
         required: false
         type: boolean
         default: false
@@ -18,9 +18,12 @@ on:
         type: boolean
         default: false
     secrets:
-      repository:
-        description: Name of the repo within Container Registry to push into
-        required: true
+      CI_BOT_TOKEN:
+        description: GITHUB_TOKEN environment variable to run merge_prs script
+        required: false
+      CI_BOT_USERNAME:
+        description: GITHUB_USERNAME environment variable to run merge_prs script
+        required: false
       gcp_project_id:
         required: true
       gcp_service_account_key:
@@ -29,6 +32,9 @@ on:
         required: false
       k8s_cluster_zone:
         required: false
+      repository:
+        description: Name of the repo within Container Registry to push into
+        required: true
       ssh_agent_private_key:
         required: true
 

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -104,7 +104,6 @@ jobs:
         run: |-
           gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
 
-
       - name: Build and push image
         uses: docker/build-push-action@v1
         with:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -40,6 +40,9 @@ on:
 
 jobs:
   Push:
+    env:
+      GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
+      GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
To build and deploy images in a generic way, hopefully.

I mashed this together from https://github.com/goodwatercap/company-tearsheet-web-client/blob/dev/.github/workflows/deploy.yml and https://github.com/goodwatercap/.github/blob/main/.github/workflows/apply.yml as part of the Redash deployment work.

---
While I was working on this, I also made a couple improvements regarding https://app.asana.com/0/1201289502507195/1202831989652774/f:
1. Used `tee` to print incremental output as the actions are running
2. Changed failure conditions: instead of `continue_on_error` (which moves the ❌ to the next step), let the step fail. Then the following steps run with `if: success() || failure()`, so that they still post comments when there are failures (see [StackOverflow](https://stackoverflow.com/questions/58858429/how-to-run-a-github-actions-step-even-if-the-previous-step-fails-while-still-f) for why I chose this over `always()`)
3. Add a `merge_stage_prs` flag for the stage env, and inline the merge_prs script
4. Make `plan.yml` work more like `apply.yml`; it was doing some weird stuff with output files that was making failures harder to find.