### PR TITLE
Pipe rollup SHAs into later steps

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -1,9 +1,14 @@
 # Runs `terraform apply` after doing the required authentication and setup.
+# Also builds and pushes a Docker container, if provided.
 name: "Apply"
 
 on:
   workflow_call:
     inputs:
+      dockerfile:
+        description: Name of a dockerfile to build and push before running Terraform.
+        required: false
+        type: string
       github_ref:
         description: Override of GITHUB_REF environment variable (ie, what branch to run tf against)
         required: false
@@ -53,6 +58,9 @@ on:
         required: false
       k8s_cluster_zone:
         required: false
+      repository:
+        description: Repository within Container Registry to push the built Docker image into.
+        required: false
       ssh_agent_private_key:
         required: true
 
@@ -89,6 +97,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
@@ -106,6 +115,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1
@@ -142,6 +152,17 @@ jobs:
         run: |-
           terraform init -backend-config="bucket=${{ secrets.tf_bucket }}" -backend-config="prefix=${{ inputs.tf_prefix }}" -reconfigure
         working-directory: ${{ inputs.tf_working_directory }}
+
+      - name: Build and push image
+        if: inputs.dockerfile
+        uses: docker/build-push-action@v1
+        with:
+          dockerfile: ${{ inputs.dockerfile }}
+          username: _json_key
+          password: ${{ secrets.gcp_service_account_key }}
+          registry: gcr.io
+          repository: ${{ secrets.repository }}
+          tags: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
 
       - name: Terraform Apply
         id: apply

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -96,9 +96,6 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
-          output=$(git rev-parse HEAD)
-          echo "HEAD is now at SHA: $output"
-          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
         id: rollup_stage
@@ -114,6 +111,10 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Get current SHA
+        id: get_sha
+        run: |-
           output=$(git rev-parse HEAD)
           echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
@@ -162,12 +163,12 @@ jobs:
           password: ${{ secrets.gcp_service_account_key }}
           registry: gcr.io
           repository: ${{ secrets.repository }}
-          tags: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
+          tags: ${{ steps.get_sha.outputs.stdout }}
 
       - name: Terraform Apply
         id: apply
         env:
-          TF_VAR_git_sha: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
+          TF_VAR_git_sha: ${{ steps.get_sha.outputs.stdout }}
         run: |-
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -75,6 +75,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Rollup open PRs
+        id: rollup_dev
         if: ${{ inputs.merge_prs }}
         run: |-
           git checkout origin/main
@@ -87,8 +88,11 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
+        id: rollup_stage
         if: ${{ inputs.merge_stage_prs }}
         run: |-
           git checkout origin/main
@@ -101,6 +105,8 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:
@@ -139,6 +145,8 @@ jobs:
 
       - name: Terraform Apply
         id: apply
+        env:
+          TF_VAR_git_sha: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
         run: |-
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -89,9 +89,6 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
-          output=$(git rev-parse HEAD)
-          echo "HEAD is now at SHA: $output"
-          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
         id: rollup_stage
@@ -107,6 +104,10 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Get current SHA
+        id: get_sha
+        run: |-
           output=$(git rev-parse HEAD)
           echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
@@ -164,7 +165,7 @@ jobs:
       - name: Terraform Plan
         id: plan
         env:
-          TF_VAR_git_sha: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
+          TF_VAR_git_sha: ${{ steps.get_sha.outputs.stdout }}
         run: |-
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -90,6 +90,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
@@ -107,6 +108,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -76,6 +76,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Rollup open PRs
+        id: rollup_dev
         if: ${{ inputs.merge_prs }}
         run: |-
           git checkout origin/main
@@ -88,8 +89,11 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
+        id: rollup_stage
         if: ${{ inputs.merge_stage_prs }}
         run: |-
           git checkout origin/main
@@ -102,6 +106,8 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:
@@ -155,6 +161,8 @@ jobs:
 
       - name: Terraform Plan
         id: plan
+        env:
+          TF_VAR_git_sha: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
         run: |-
           # Write the input to the varfile without substitution
           cat <<- EOF >> terraform.tfvars.json

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -1,3 +1,5 @@
+# Build and push a Docker image.
+# To build an image and use it within Terraform, prefer passing your dockerfile into apply.yml instead.
 name: "Build and Push Image"
 
 on:

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -77,9 +77,6 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
-          output=$(git rev-parse HEAD)
-          echo "HEAD is now at SHA: $output"
-          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
         id: rollup_stage
@@ -95,6 +92,10 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+
+      - name: Get current SHA
+        id: get_sha
+        run: |-
           output=$(git rev-parse HEAD)
           echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
@@ -130,4 +131,4 @@ jobs:
           password: ${{ secrets.gcp_service_account_key }}
           registry: gcr.io
           repository: ${{ secrets.repository }}
-          tags: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}
+          tags: ${{ steps.get_sha.outputs.stdout }}

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -62,6 +62,7 @@ jobs:
           git config user.email github-actions@github.com
 
       - name: Rollup open PRs
+        id: rollup_dev
         if: ${{ inputs.merge_prs }}
         run: |-
           git checkout origin/main
@@ -74,8 +75,11 @@ jobs:
           gh pr list --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
+        id: rollup_stage
         if: ${{ inputs.merge_stage_prs }}
         run: |-
           git checkout origin/main
@@ -88,6 +92,8 @@ jobs:
           gh pr list --label=stage --draft=false --base=main --limit=100 --json number,headRefName,mergeable \
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
+          output=$(git rev-parse HEAD)
+          echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1
         with:
@@ -120,4 +126,4 @@ jobs:
           password: ${{ secrets.gcp_service_account_key }}
           registry: gcr.io
           repository: ${{ secrets.repository }}
-          tags: ${{ github.sha }}
+          tags: ${{ steps.rollup_stage.outputs.stdout || steps.rollup_dev.outputs.stdout || github.sha }}

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -76,6 +76,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - name: Rollup open stage PRs
@@ -93,6 +94,7 @@ jobs:
             -t "{{ range . }}{{ .number }} {{ .headRefName }} {{ .mergeable }}
           {{end}}" | grep MERGEABLE | sort -n | cut -d ' ' -f2 | xargs -I{} -n1 git merge origin/{}
           output=$(git rev-parse HEAD)
+          echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
       - uses: webfactory/ssh-agent@v0.4.1


### PR DESCRIPTION
There was some funny business going on here.
Since we're triggering via comments, the `git_sha` we were passing in was actually the SHA for the `main` branch of the repo, which is not great (it means that ~a. dev/stage builds are overwriting the latest prod build,~ and b. TF is not doing a good job of identifying when changes are being made).

Instead, use the actual SHA of the merged branches. This does mean that identical dev/stage runs will still have different SHAs, but that's... probably fine?

*: actually, they're only overwriting other dev/stage builds, they're inside separate GCR repos