### PR TITLE
setup-gcloud: update and set version

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -75,6 +75,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
+      HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -142,26 +143,37 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: webfactory/ssh-agent@v0.4.1
+        with:
+          ssh-private-key: ${{ secrets.ssh_agent_private_key }}
+
+      - uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp_project_id }}
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
-      - uses: google-github-actions/setup-gcloud@v0 # terraform-bot
+      - name: Use System GCloud
+        uses: google-github-actions/setup-gcloud@v1
+        if: ${{ ! env.HAS_CREDENTIALS }}
         with:
+          skip_install: True
+
+      - name: Setup GCloud with GKE Auth Plugin
+        uses: google-github-actions/setup-gcloud@v1
+        if: env.HAS_CREDENTIALS
+        with:
+          version: '>= 422.0.0'
           install_components: "gke-gcloud-auth-plugin"
 
-      - run: |-
-          gcloud --quiet auth configure-docker
-
-      # Get the GKE credentials, so we can apply against the cluster
+      # Get the GKE credentials, so we can plan against the cluster
       - name: get-credentials
         # Workaround to https://github.com/actions/runner/issues/520
-        env:
-          HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
         if: env.HAS_CREDENTIALS
         run: |-
           gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
+
+      - run: |-
+          gcloud --quiet auth configure-docker
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.2.1

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -135,13 +135,14 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: google-github-actions/auth@v0
+      - uses: google-github-actions/auth@v1
         with:
           project_id: ${{ secrets.gcp_project_id }}
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
-      - uses: google-github-actions/setup-gcloud@v0 # terraform-bot
+      - uses: google-github-actions/setup-gcloud@v1
         with:
+          version: '>= 422.0.0'
           install_components: "gke-gcloud-auth-plugin"
 
       - run: |-

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -68,6 +68,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
+      HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -141,21 +142,25 @@ jobs:
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
       - uses: google-github-actions/setup-gcloud@v1
+        if: !env.HAS_CREDENTIALS
+        with:
+          skip_install: True
+
+      - uses: google-github-actions/setup-gcloud@v1
+        if: env.HAS_CREDENTIALS
         with:
           version: '>= 422.0.0'
           install_components: "gke-gcloud-auth-plugin"
 
-      - run: |-
-          gcloud --quiet auth configure-docker
-
       # Get the GKE credentials, so we can plan against the cluster
       - name: get-credentials
         # Workaround to https://github.com/actions/runner/issues/520
-        env:
-          HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
         if: env.HAS_CREDENTIALS
         run: |-
           gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
+
+      - run: |-
+          gcloud --quiet auth configure-docker
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.2.1

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -161,9 +161,6 @@ jobs:
         run: |-
           gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
 
-      - run: |-
-          gcloud --quiet auth configure-docker
-
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1.2.1
         with:

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -142,7 +142,7 @@ jobs:
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
       - uses: google-github-actions/setup-gcloud@v1
-        if: !env.HAS_CREDENTIALS
+        if: ${{ ! env.HAS_CREDENTIALS }}
         with:
           skip_install: True
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -141,12 +141,14 @@ jobs:
           project_id: ${{ secrets.gcp_project_id }}
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
-      - uses: google-github-actions/setup-gcloud@v1
+      - name: Use System GCloud
+        uses: google-github-actions/setup-gcloud@v1
         if: ${{ ! env.HAS_CREDENTIALS }}
         with:
           skip_install: True
 
-      - uses: google-github-actions/setup-gcloud@v1
+      - name: Setup GCloud with GKE Auth Plugin
+        uses: google-github-actions/setup-gcloud@v1
         if: env.HAS_CREDENTIALS
         with:
           version: '>= 422.0.0'

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -55,6 +55,7 @@ jobs:
     env:
       GITHUB_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
       GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
+      HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -109,26 +110,28 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: google-github-actions/auth@v0
+      - name: Use System GCloud
+        uses: google-github-actions/setup-gcloud@v1
+        if: ${{ ! env.HAS_CREDENTIALS }}
         with:
-          project_id: ${{ secrets.gcp_project_id }}
-          credentials_json: ${{ secrets.gcp_service_account_key }}
+          skip_install: True
 
-      - uses: google-github-actions/setup-gcloud@v0 # terraform-bot
+      - name: Setup GCloud with GKE Auth Plugin
+        uses: google-github-actions/setup-gcloud@v1
+        if: env.HAS_CREDENTIALS
         with:
+          version: '>= 422.0.0'
           install_components: "gke-gcloud-auth-plugin"
 
-      - run: |-
-          gcloud --quiet auth configure-docker
-
-      # Get the GKE credentials, so we can apply against the cluster
+      # Get the GKE credentials, so we can plan against the cluster
       - name: get-credentials
         # Workaround to https://github.com/actions/runner/issues/520
-        env:
-          HAS_CREDENTIALS: ${{ secrets.k8s_cluster_id && secrets.k8s_cluster_zone }}
         if: env.HAS_CREDENTIALS
         run: |-
           gcloud container clusters get-credentials ${{ secrets.k8s_cluster_id }} --zone ${{ secrets.k8s_cluster_zone }}
+
+      - run: |-
+          gcloud --quiet auth configure-docker
 
       - name: Setup Node
         if:  ${{ inputs.yarn }}


### PR DESCRIPTION
> skip_install: (Optional) Skip the gcloud installation and use the [system-installed gcloud](https://github.com/actions/runner-images) instead. This can dramatically improve workflow speeds at the expense of a slightly older gcloud version. Setting this to true ignores any value for the version input. If you skip installation, you will be unable to install components because the system-install gcloud is locked. The default value is false.

from [docs](https://github.com/google-github-actions/setup-gcloud#cloud-sdk-inputs)