### PR TITLE
Bump up all actions to their node20 versions

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -165,7 +165,7 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         with:
           project_id: ${{ secrets.gcp_project_id }}
           credentials_json: ${{ secrets.gcp_service_account_key }}

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -86,7 +86,7 @@ jobs:
       GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref:  ${{ inputs.github_ref }}
           fetch-depth: 0
@@ -151,19 +151,19 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: google-github-actions/auth@v1
+      - uses: google-github-actions/auth@v2
         with:
           project_id: ${{ secrets.gcp_project_id }}
           credentials_json: ${{ secrets.gcp_service_account_key }}
 
       - name: Use System GCloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         if: ${{ ! inputs.really_actually_use_k8s }}
         with:
           skip_install: True
 
       - name: Setup GCloud with GKE Auth Plugin
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         if: inputs.really_actually_use_k8s
         with:
           version: '>= 422.0.0'
@@ -252,7 +252,7 @@ jobs:
         working-directory: ${{ inputs.tf_working_directory }}
         run: echo "Logs trimmed due to size" > full_output.txt
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: inputs.post_result_comment && (success() || failure())
         with:
           script: |

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -120,13 +120,13 @@ jobs:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
       - name: Use System GCloud
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         if: ${{ ! inputs.really_actually_use_k8s }}
         with:
           skip_install: True
 
       - name: Setup GCloud with GKE Auth Plugin
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         if: inputs.really_actually_use_k8s
         with:
           version: '>= 422.0.0'

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -87,7 +87,7 @@ jobs:
         run: terraform validate -no-color
         working-directory: ${{ inputs.tf_working_directory }}
 
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         if: inputs.post_result_comment && (success() || failure())
         with:
           script: |


### PR DESCRIPTION
Upgrades most of the actions from their Node16 version to their Node20 versions.

The ssh-agent and the setup-terraform actions are still on their Node12 versions 😳 I'll have a follow up PR to change those...seems significant enough that I want to isolate those just in case.