### PR TITLE
Final node 20 upgrades

### DIFF
--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -220,7 +220,7 @@ jobs:
           private_key: ${{ secrets.GW_CI_BOT_APP_SECRET }}
 
       - name: Extend Git credentials
-        uses: de-vri-es/setup-git-credentials@v2.0.10
+        uses: de-vri-es/setup-git-credentials@v2.1.2
         with:
           credentials: https://user:${{ steps.get_application_token.outputs.token }}@github.com
 

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -202,7 +202,7 @@ jobs:
           touch full_output.txt
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+        uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: ${{ steps.get_tf_version.outputs.tf_version }}
           terraform_wrapper: false

--- a/.github/workflows/apply.yml
+++ b/.github/workflows/apply.yml
@@ -157,11 +157,11 @@ jobs:
             echo "tf_version=$input_version" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -147,7 +147,7 @@ jobs:
             echo "tf_version=$input_version" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -189,7 +189,7 @@ jobs:
           touch plan_errors.txt
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+        uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: ${{ steps.get_tf_version.outputs.tf_version }}
           terraform_wrapper: false

--- a/.github/workflows/push_image.yml
+++ b/.github/workflows/push_image.yml
@@ -67,7 +67,7 @@ jobs:
       GITHUB_USERNAME: ${{ secrets.CI_BOT_USERNAME }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref:  ${{ inputs.github_ref }}
           fetch-depth: 0
@@ -115,7 +115,7 @@ jobs:
           echo "HEAD is now at SHA: $output"
           echo "::set-output name=stdout::$output"
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -59,7 +59,7 @@ jobs:
           fi
 
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v1.2.1
+        uses: hashicorp/setup-terraform@v3.0.0
         with:
           terraform_version: ${{ inputs.tf_version }}
           terraform_wrapper: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
     name: Terraform Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           ref:  ${{ inputs.github_ref }}
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           ref:  ${{ inputs.github_ref }}
 
-      - uses: webfactory/ssh-agent@v0.4.1
+      - uses: webfactory/ssh-agent@v0.9.0
         with:
           ssh-private-key: ${{ secrets.ssh_agent_private_key }}
 


### PR DESCRIPTION
Final node20 upgrades, release notes below:

- de-vri-es/setup-git-credentials: https://github.com/de-vri-es/setup-git-credentials/releases
- hashicorp/setup-terraform: https://github.com/hashicorp/setup-terraform/releases
- webfactory/ssh-agent: https://github.com/webfactory/ssh-agent/releases