### PR TITLE
remove tfsec from plan and validate

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -370,26 +370,3 @@ jobs:
                 body: output
               })
             }
-
-      - name: get_tfsec_flags
-        id: get_tfsec_flags
-        if: success() || failure()
-        run: |-
-          if [[ -f tfsec.json ]]; then
-            flags="--config-file tfsec.json"
-          else
-            flags=""
-          fi
-          echo "Setting flags: $flags"
-          echo "flags=$flags" >> "$GITHUB_OUTPUT"
-
-      - name: tfsec
-        if: success() || failure()
-        uses: reviewdog/action-tfsec@master
-        with:
-          reporter: github-pr-review
-          fail_on_error: "false"
-          filter_mode: "nofilter" # Check all files, not just the diff
-          flags: -tee
-          tfsec_version: "v1.28.1"
-          tfsec_flags: "${{ steps.get_tfsec_flags.outputs.flags }}"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -127,11 +127,3 @@ jobs:
                 body: output
               })
             }
-
-      - name: tfsec
-        if: success() || failure()
-        uses: reviewdog/action-tfsec@master
-        with:
-          reporter: github-pr-review
-          fail_on_error: "false"
-          filter_mode: "nofilter" # Check all files, not just the diff


### PR DESCRIPTION
tfsec has hamstrung the oasis-data-pipeline release process and not provided any value (that I know of). 

This PR removes it completely from the CI/CD plan and validate steps that run in both oasis-data-pipeline and core-service. 